### PR TITLE
Improve on learning performance

### DIFF
--- a/hilbert_mapper/src/hilbertmap.cpp
+++ b/hilbert_mapper/src/hilbertmap.cpp
@@ -106,8 +106,18 @@ void hilbertmap::setMapCenter(Eigen::Vector3d map_center){
 }
 
 void hilbertmap::getkernelVector(Eigen::Vector3d x_query, Eigen::VectorXd &kernel_vector){
+// TODO: Vecotrized calculation is slower
+
+//    Eigen::VectorXd r;
+//    Eigen::MatrixXd anchorpoints = Eigen::MatrixXd::Zero(3, anchorpoints_.size());
+//    for(int i; i < anchorpoints_.size(); i++){
+//        anchorpoints.col(i) = anchorpoints_[i];
+//    }
+//    r = (anchorpoints.colwise()-=x_query).colwise().squaredNorm();
+//    kernel_vector = (-0.5 * ( (1/sigma_) *r.array() ).pow(2)).exp().matrix();
+ double kernel, r;
+
     for(int i = 0; i < kernel_vector.size(); i++){
-        double kernel, r;
 
         r = (x_query - anchorpoints_[i]).norm();
         kernel = exp(-0.5 * pow(r/sigma_, 2));

--- a/hilbert_mapper/src/hilbertmap.cpp
+++ b/hilbert_mapper/src/hilbertmap.cpp
@@ -7,7 +7,7 @@
 hilbertmap::hilbertmap(int num_features):
     num_features_(num_features),
     num_samples_(30),
-    max_iterations_(100),
+    max_iterations_(30),
     weights_(Eigen::VectorXd::Zero(num_features)),
     A_(Eigen::MatrixXd::Identity(num_features, num_features)),
     eta_(0.7),

--- a/hilbert_mapper/src/hilbertmap.cpp
+++ b/hilbert_mapper/src/hilbertmap.cpp
@@ -115,15 +115,11 @@ void hilbertmap::getkernelVector(Eigen::Vector3d x_query, Eigen::VectorXd &kerne
 //    }
 //    r = (anchorpoints.colwise()-=x_query).colwise().squaredNorm();
 //    kernel_vector = (-0.5 * ( (1/sigma_) *r.array() ).pow(2)).exp().matrix();
- double kernel, r;
+    double kernel, r;
 
-    for(int i = 0; i < kernel_vector.size(); i++){
+    for(int i = 0; i < kernel_vector.size(); i++)
+        kernel_vector(i) = exp(-0.5 * pow((x_query - anchorpoints_[i]).norm()/sigma_, 2));
 
-        r = (x_query - anchorpoints_[i]).norm();
-        kernel = exp(-0.5 * pow(r/sigma_, 2));
-
-        kernel_vector(i) = kernel;
-    }
 }
 
 void hilbertmap::generateGridPoints(std::vector<Eigen::Vector3d> &gridpoints, Eigen::Vector3d center, double width, double length, double height, double resolution){


### PR DESCRIPTION
This PR only includes changes in the parameters on the number of iterations for the stochastic gradient descent while not compromising much of the map stability.

A failed attempt of vectorized calculation using `Eigen`  is commented out.

A brief performance is as the following.

|   |  Query Time | Gradient Descent  | 
|---|---|---|
| Release  | 2.5 * e-5 s  |   0.04 s | 
| Debug  | 5.6 * e-4 s | 0.3 s |  
