### PR TITLE
Receive pointcloud through tsdf server

### DIFF
--- a/hilbert_loco_planner/include/hilbert_loco_planner/hilbert_loco_planner.h
+++ b/hilbert_loco_planner/include/hilbert_loco_planner/hilbert_loco_planner.h
@@ -30,7 +30,6 @@ public:
     static constexpr int kN = 10;
 
     HilbertLocoPlanner(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
-    virtual ~ HilbertLocoPlanner();
 
     void setHilbertMap(const std::shared_ptr<hilbertmap>& hilbert_map);
 

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -12,7 +12,7 @@ hilbertMapper::hilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& n
 
     hilbertMap_.reset(new hilbertmap(1000));
 
-    cmdloop_timer_ = nh_.createTimer(ros::Duration(2), &hilbertMapper::cmdloopCallback, this); // Define timer for constant loop rate
+    cmdloop_timer_ = nh_.createTimer(ros::Duration(0.25), &hilbertMapper::cmdloopCallback, this); // Define timer for constant loop rate
     statusloop_timer_ = nh_.createTimer(ros::Duration(2), &hilbertMapper::statusloopCallback, this); // Define timer for constant loop rate
 
     mapinfoPub_ = nh_.advertise<hilbert_msgs::MapperInfo>("/hilbert_mapper/info", 1);

--- a/mav_hilbert_planner/include/mav_hilbert_planner/mav_hilbert_planner.h
+++ b/mav_hilbert_planner/include/mav_hilbert_planner/mav_hilbert_planner.h
@@ -64,6 +64,7 @@ class MavHilbertPlanner {
 
   // Control for planning.
   void planningTimerCallback(const ros::TimerEvent& event);
+  void hilbertmapTimerCallback(const ros::TimerEvent& event);
   void planningStep();
   // Returns if the next waypoint is a valid waypoint.
   bool nextWaypoint();
@@ -117,11 +118,13 @@ class MavHilbertPlanner {
   ros::CallbackQueue command_publishing_queue_;
   ros::AsyncSpinner command_publishing_spinner_;
   ros::CallbackQueue planning_queue_;
+  ros::CallbackQueue hilbertmap_queue_;
   ros::AsyncSpinner planning_spinner_;
 
   // Publisher for new messages to the controller.
   ros::Timer command_publishing_timer_;
   ros::Timer planning_timer_;
+  ros::Timer hilbertmapupdate_timer_;
 
   // Settings -- general
   bool verbose_;
@@ -139,6 +142,8 @@ class MavHilbertPlanner {
   double command_publishing_dt_;
   double replan_dt_;
   double replan_lookahead_sec_;
+
+  double maprefresh_dt_;
 
   // Settings -- general planning.
   bool avoid_collisions_;

--- a/mav_hilbert_planner/include/mav_hilbert_planner/mav_hilbert_planner.h
+++ b/mav_hilbert_planner/include/mav_hilbert_planner/mav_hilbert_planner.h
@@ -23,7 +23,7 @@
 #include <mav_visualization/helpers.h>
 #include <minkindr_conversions/kindr_msg.h>
 #include <hilbert_loco_planner/hilbert_loco_planner.h>
-#include <voxblox_ros/esdf_server.h>
+#include <voxblox_ros/tsdf_server.h>
 
 namespace mav_planning {
 
@@ -167,6 +167,7 @@ class MavHilbertPlanner {
 
   // Map!
   hilbertMapper hilbert_mapper_;
+  voxblox::TsdfServer tsdf_server_;
 
   // Planners -- yaw policy
   YawPolicy yaw_policy_;

--- a/mav_hilbert_planner/launch/firefly_mapping_planning.launch
+++ b/mav_hilbert_planner/launch/firefly_mapping_planning.launch
@@ -30,39 +30,9 @@
       <param name="verbose" value="false" />
     </node>
 
-   <remap from="/$(arg mav_name)/ground_truth/pose" to="/hilbert_mapper/map_center/mavtf"/>
-   <remap from="/firefly/mav_hilbert_planner/tsdf_pointcloud" to="/hilbert_mapper/tsdf_pointcloud"/>
+    <remap from="/$(arg mav_name)/ground_truth/pose" to="/hilbert_mapper/map_center/mavtf"/>
+    <remap from="/firefly/mav_hilbert_planner/tsdf_pointcloud" to="/hilbert_mapper/tsdf_pointcloud"/>
 
-  <!--
-   <node name="mav_local_planner" pkg="mav_local_planner" type="mav_local_planner_node" output="screen">
-     <remap from="odometry" to="ground_truth/odometry" />
-     <remap from="mav_local_planner/esdf_map_in" to="esdf_map" />
-     <remap from="mav_local_planner/tsdf_map_in" to="tsdf_map" />
-
-     <param name="tsdf_voxel_size" value="$(arg voxel_size)" />
-     <param name="tsdf_voxels_per_side" value="16" />
-     <param name="esdf_max_distance_m" value="2.0" />
-     <param name="update_mesh_every_n_sec" value="0.0" />
-     <param name="publish_traversable" value="true" />
-     <param name="slice_level" value="1.0" />
-     <param name="publish_slices" value="true" />
-
-     <param name="local_frame_id" value="$(arg frame_id)" />
-     <param name="world_frame" value="$(arg frame_id)" />
-     <param name="replan_dt" value="0.25" />
-     <param name="command_publishing_dt" value="0.25" />
-     <param name="replan_lookahead_sec" value="1.0" />
-     <param name="mpc_prediction_horizon" value="300" />
-
-     <param name="robot_radius" value="0.5" />
-     <param name="planning_horizon_m" value="4.0" />
-     <param name="autostart" value="true" />
-     <param name="verbose" value="true" />
-     <param name="v_max" value="2.0" />
-     <param name="a_max" value="2.0" />
-     <param name="avoid_collisions" value="true" />
-   </node>
-  -->
     <node name="mav_hilbert_planner" pkg="mav_hilbert_planner" type="mav_hilbert_planner_node" output="screen">
       <remap from="odometry" to="ground_truth/odometry" />
       <remap from="mav_hilbert_planner/esdf_map_in" to="esdf_map" />
@@ -75,6 +45,8 @@
       <param name="publish_traversable" value="true" />
       <param name="slice_level" value="1.0" />
       <param name="publish_slices" value="true" />
+      <param name="publish_pointclouds" value="true"/>
+      <param name="publish_tsdf_info" value="true"/>
 
       <param name="local_frame_id" value="$(arg frame_id)" />
       <param name="world_frame" value="$(arg frame_id)" />

--- a/mav_hilbert_planner/src/mav_hilbert_planner.cpp
+++ b/mav_hilbert_planner/src/mav_hilbert_planner.cpp
@@ -160,7 +160,7 @@ void MavHilbertPlanner::waypointListCallback(
 
 void MavHilbertPlanner::planningTimerCallback(const ros::TimerEvent& event) {
   // Wait on the condition variable from the publishing...
-  hilbert_mapper_.setMapCenter(odometry_.position_W);
+  // hilbert_mapper_.setMapCenter(odometry_.position_W);
   if (should_replan_.wait_for(replan_dt_)) {
     planningStep();
   }

--- a/mav_hilbert_planner/src/mav_hilbert_planner.cpp
+++ b/mav_hilbert_planner/src/mav_hilbert_planner.cpp
@@ -26,6 +26,7 @@ MavHilbertPlanner::MavHilbertPlanner(const ros::NodeHandle& nh,
       max_failures_(5),
       num_failures_(0),
       hilbert_mapper_(nh_, nh_private_),
+      tsdf_server_(nh_, nh_private_),
       loco_planner_(nh_, nh_private_) {
   // Set up some settings.
   constraints_.setParametersFromRos(nh_private_);

--- a/mav_hilbert_planner/src/mav_hilbert_planner.cpp
+++ b/mav_hilbert_planner/src/mav_hilbert_planner.cpp
@@ -18,6 +18,7 @@ MavHilbertPlanner::MavHilbertPlanner(const ros::NodeHandle& nh,
       command_publishing_dt_(1.0),
       replan_dt_(1.0),
       replan_lookahead_sec_(0.1),
+      maprefresh_dt_(10.0),
       avoid_collisions_(true),
       autostart_(true),
       smoother_name_("loco"),
@@ -74,11 +75,19 @@ MavHilbertPlanner::MavHilbertPlanner(const ros::NodeHandle& nh,
 
   // Start the planning timer. Will no-op most cycles.
   ros::TimerOptions timer_options(
-      ros::Duration(replan_dt_),
+      ros::Duration(maprefresh_dt_),
       boost::bind(&MavHilbertPlanner::planningTimerCallback, this, _1),
       &planning_queue_);
 
   planning_timer_ = nh_.createTimer(timer_options);
+
+  ros::TimerOptions map_timer_options(
+    ros::Duration(replan_dt_),
+    boost::bind(&MavHilbertPlanner::hilbertmapTimerCallback, this, _1),
+    &hilbertmap_queue_);
+
+
+  hilbertmapupdate_timer_ = nh_.createTimer(map_timer_options);
 
   // Start the command publishing spinner.
   command_publishing_spinner_.start();
@@ -160,10 +169,13 @@ void MavHilbertPlanner::waypointListCallback(
 
 void MavHilbertPlanner::planningTimerCallback(const ros::TimerEvent& event) {
   // Wait on the condition variable from the publishing...
-  // hilbert_mapper_.setMapCenter(odometry_.position_W);
   if (should_replan_.wait_for(replan_dt_)) {
     planningStep();
   }
+}
+
+void MavHilbertPlanner::hilbertmapTimerCallback(const ros::TimerEvent& event) {
+    hilbert_mapper_.setMapCenter(odometry_.position_W);
 }
 
 void MavHilbertPlanner::planningStep() {


### PR DESCRIPTION
This PR integrates receiving the pointcloud through the `voxblox::TsdfServer` from `mav_hilbert_planner`

In order to achieve this, the following has been done.
- Modified launchfile for remaps
- add tsdf server as  a member in `mav_hilbert_planner`
- Add a separate loop that updates the map center slower than the replanning rate


![screenshot from 2019-02-25 12-07-09](https://user-images.githubusercontent.com/5248102/53333655-c7ff0500-38f6-11e9-9055-263cac11cb44.png)

