### PR TITLE
Debug Double free memory issue from ceres

### DIFF
--- a/hilbert_loco_planner/src/hilbert_loco_planner.cpp
+++ b/hilbert_loco_planner/src/hilbert_loco_planner.cpp
@@ -153,7 +153,7 @@ bool HilbertLocoPlanner::getTrajectoryBetweenWaypoints(
 
 double HilbertLocoPlanner::getOccProb(const Eigen::Vector3d& position) const {
     double occprob = 0.0;
-    if (!hilbert_map_->getOccProbAtPosition(position, occprob)) {
+    if (!hilbert_map_->getOccProbAtPosition(position, &occprob)) {
         return 0.0;
     }
     return occprob;
@@ -161,7 +161,7 @@ double HilbertLocoPlanner::getOccProb(const Eigen::Vector3d& position) const {
 
 double HilbertLocoPlanner::getOccProbAndGradient(const Eigen::Vector3d& position, Eigen::Vector3d* gradient) const {
     double occprob = 0.0;
-    if(!hilbert_map_->getOccProbAndGradientAtPosition(position, occprob, gradient)){
+    if(!hilbert_map_->getOccProbAndGradientAtPosition(position, &occprob, gradient)){
         return 0.0;
     }
     return occprob;
@@ -170,11 +170,15 @@ double HilbertLocoPlanner::getOccProbAndGradient(const Eigen::Vector3d& position
 
 double HilbertLocoPlanner::getOccProbAndGradientVector(const Eigen::VectorXd& position, Eigen::VectorXd* gradient) const {
     CHECK_EQ(position.size(), 3);
+
+    Eigen::Vector3d gradient_3d;
+
     if (gradient == nullptr) {
         return getOccProbAndGradient(position, nullptr);
     }
-    Eigen::Vector3d gradient_3d;
+
     double occprob = getOccProbAndGradient(position, &gradient_3d);
+
     *gradient = gradient_3d;
     return occprob;
 }

--- a/hilbert_mapper/include/hilbert_mapper/hilbertmap.h
+++ b/hilbert_mapper/include/hilbert_mapper/hilbertmap.h
@@ -49,10 +49,9 @@ public:
         int getBinSize();
         int getNumFeatures();
         double getOccupancyProb(const Eigen::Vector3d &x_query) const;
-        double getOccupancyProbAndGradient(const Eigen::Vector3d &x_query, Eigen::Vector3d* gradient) const;
         double voxel_size(){ return 0.5 * resolution_; };
-        bool getOccProbAtPosition(const Eigen::Vector3d& x_query, double &occprob) const;
-        bool getOccProbAndGradientAtPosition(const Eigen::Vector3d& x_query, double &occprob, Eigen::Vector3d* gradient) const;
+        bool getOccProbAtPosition(const Eigen::Vector3d& x_query, double* occprob) const;
+        bool getOccProbAndGradientAtPosition(const Eigen::Vector3d& x_query, double* occprob, Eigen::Vector3d* gradient) const;
 
         double getMapWidth();
         double getMapResolution();

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -45,7 +45,7 @@ hilbertMapper::~hilbertMapper() {
 void hilbertMapper::cmdloopCallback(const ros::TimerEvent& event) {
 
     hilbertMap_->updateWeights();
-    ros::spinOnce();
+    // ros::spinOnce();
 }
 
 void hilbertMapper::statusloopCallback(const ros::TimerEvent &event) {

--- a/hilbert_mapper/src/hilbertmap.cpp
+++ b/hilbert_mapper/src/hilbertmap.cpp
@@ -238,13 +238,11 @@ bool hilbertmap::getOccProbAndGradientAtPosition(const Eigen::Vector3d &x_query,
     //  Calculate gradient
     //  dk = ( -1/(0.5*radius^2) ) * phi_hat .*delta_x;
     for(int i; i < anchorpoints_.size(); i++){ //Copy Anchorpoints
-        anchorpoints.row(i) = anchorpoints_[i];
+        anchorpoints.col(i) = anchorpoints_[i];
     }
 
-
     delta_x = anchorpoints.colwise() - x_query; //TODO: confirm sign
-    occupancy_gradient = ((-1/(0.5*pow(sigma_, 2))) * phi_x * delta_x).transpose();
-    return probability;
+    occupancy_gradient = (-1/(0.5*pow(sigma_, 2))) * delta_x * phi_x;
 
     *occprob = occupancy_prob;
     *gradient = occupancy_gradient;

--- a/hilbert_mapper/src/hilbertmap.cpp
+++ b/hilbert_mapper/src/hilbertmap.cpp
@@ -214,37 +214,43 @@ double hilbertmap::getOccupancyProb(const Eigen::Vector3d &x_query) const {
     return probability;
 }
 
-double hilbertmap::getOccupancyProbAndGradient(const Eigen::Vector3d &x_query, Eigen::Vector3d* gradient) const {
+bool hilbertmap::getOccProbAtPosition(const Eigen::Vector3d& x_query, double* occprob) const {
+    *occprob = getOccupancyProb(x_query);
+    if(*occprob > 1.0 || *occprob < 0.0) return false; //Sanity Check
+    return true;
+}
 
-    double probability;
+bool hilbertmap::getOccProbAndGradientAtPosition(const Eigen::Vector3d &x_query, double* occprob ,Eigen::Vector3d* gradient) const {
+    bool success = false;
+    double occupancy_prob;
     Eigen::VectorXd phi_x;
-    Eigen::MatrixXd delta_x = Eigen::MatrixXd::Zero(3, anchorpoints_.size());
-    Eigen::MatrixXd anchorpoints = Eigen::MatrixXd::Zero(3, anchorpoints_.size());
+    Eigen::Vector3d occupancy_gradient;
     ros::Time start_time;
 
+    Eigen::MatrixXd delta_x = Eigen::MatrixXd::Zero(3, anchorpoints_.size());
+    Eigen::MatrixXd anchorpoints = Eigen::MatrixXd::Zero(3, anchorpoints_.size());
+    
     phi_x = Eigen::VectorXd::Zero(num_features_);
     getkernelVector(x_query, phi_x);
 
-    probability = 1 / ( 1 + exp(weights_.dot(phi_x)));
+    occupancy_prob = 1 / ( 1 + exp(weights_.dot(phi_x)));
 
     //  Calculate gradient
     //  dk = ( -1/(0.5*radius^2) ) * phi_hat .*delta_x;
-    for(int i; i < anchorpoints_.size(); i++){
+    for(int i; i < anchorpoints_.size(); i++){ //Copy Anchorpoints
         anchorpoints.row(i) = anchorpoints_[i];
     }
+
+
     delta_x = anchorpoints.colwise() - x_query; //TODO: confirm sign
-    *gradient = ((-1/(0.5*pow(this->sigma_, 2))) * phi_x * delta_x).transpose();
+    occupancy_gradient = ((-1/(0.5*pow(sigma_, 2))) * phi_x * delta_x).transpose();
     return probability;
-}
 
-bool hilbertmap::getOccProbAtPosition(const Eigen::Vector3d& x_query, double &occprob) const {
-    occprob = getOccupancyProb(x_query);
-    if(occprob > 1.0 || occprob < 0.0) return false; //Sanity Check
-    return true;
-}
+    *occprob = occupancy_prob;
+    *gradient = occupancy_gradient;
 
-bool hilbertmap::getOccProbAndGradientAtPosition(const Eigen::Vector3d& x_query, double &occprob ,Eigen::Vector3d* gradient) const {
-    occprob = getOccupancyProbAndGradient(x_query, gradient);
-    if(occprob > 1.0 || occprob < 0.0) return false; //Sanity Check
-    return true;
+    if(occupancy_prob > 1.0 || occupancy_prob < 0.0) return success; //Sanity Check
+    success = true;
+
+    return success;
 }

--- a/mav_hilbert_planner/src/mav_hilbert_planner.cpp
+++ b/mav_hilbert_planner/src/mav_hilbert_planner.cpp
@@ -500,7 +500,7 @@ void MavHilbertPlanner::visualizePath() {
 
 double MavHilbertPlanner::getMapDistance(const Eigen::Vector3d& position) const {
   double occprob = 0.0;
-  if (!hilbert_mapper_.getHilbertMapPtr()->getOccProbAtPosition(position, occprob)) {
+  if (!hilbert_mapper_.getHilbertMapPtr()->getOccProbAtPosition(position, &occprob)) {
     return 0.0;
   }
   return occprob;
@@ -509,7 +509,7 @@ double MavHilbertPlanner::getMapDistance(const Eigen::Vector3d& position) const 
 double MavHilbertPlanner::getMapDistanceAndGradient(
     const Eigen::Vector3d& position, Eigen::Vector3d* gradient) const {
   double occprob = 0.0;
-  if (!hilbert_mapper_.getHilbertMapPtr()->getOccProbAndGradientAtPosition(position, occprob, gradient)) {
+  if (!hilbert_mapper_.getHilbertMapPtr()->getOccProbAndGradientAtPosition(position, &occprob, gradient)) {
     return 0.0;
   }
   return occprob;


### PR DESCRIPTION
This PR fixes a double free memory corruption error that was caused by having a wrong interface for the distance function