### PR TITLE
Plat trajectory in hilbertmaps

### DIFF
--- a/hilbert_loco_planner/src/hilbert_loco_planner.cpp
+++ b/hilbert_loco_planner/src/hilbert_loco_planner.cpp
@@ -25,10 +25,10 @@ HilbertLocoPlanner::HilbertLocoPlanner(const ros::NodeHandle& nh, const ros::Nod
 
     loco_.setRobotRadius(constraints_.robot_radius);
 
-    double loco_epsilon_inflation = 0.5;
+    double loco_epsilon_inflation = 0.01; //Small epsilon for probability costs
     nh_private_.param("loco_epsilon_inflation", loco_epsilon_inflation,
                     loco_epsilon_inflation);
-    loco_.setEpsilon(constraints_.robot_radius + loco_epsilon_inflation);
+    loco_.setEpsilon(loco_epsilon_inflation);
 
 }
 

--- a/hilbert_loco_planner/src/hilbert_loco_planner.cpp
+++ b/hilbert_loco_planner/src/hilbert_loco_planner.cpp
@@ -184,7 +184,7 @@ double HilbertLocoPlanner::getOccProbAndGradientVector(const Eigen::VectorXd& po
 }
 
 bool HilbertLocoPlanner::isPathCollisionFree(const mav_msgs::EigenTrajectoryPointVector& path) const {
-    return false;
+    return true;
 }
 bool HilbertLocoPlanner::isPathFeasible(const mav_msgs::EigenTrajectoryPointVector& path) const {
     return true;

--- a/mav_hilbert_planner/include/mav_hilbert_planner/mav_hilbert_planner.h
+++ b/mav_hilbert_planner/include/mav_hilbert_planner/mav_hilbert_planner.h
@@ -118,8 +118,9 @@ class MavHilbertPlanner {
   ros::CallbackQueue command_publishing_queue_;
   ros::AsyncSpinner command_publishing_spinner_;
   ros::CallbackQueue planning_queue_;
-  ros::CallbackQueue hilbertmap_queue_;
+  ros::CallbackQueue maprefresh_queue_;
   ros::AsyncSpinner planning_spinner_;
+  ros::AsyncSpinner maprefresh_spinner_;
 
   // Publisher for new messages to the controller.
   ros::Timer command_publishing_timer_;

--- a/mav_hilbert_planner/launch/firefly_mapping_planning.launch
+++ b/mav_hilbert_planner/launch/firefly_mapping_planning.launch
@@ -55,7 +55,7 @@
       <param name="replan_lookahead_sec" value="1.0" />
       <param name="mpc_prediction_horizon" value="300" />
 
-      <param name="robot_radius" value="0.5" />
+      <param name="robot_radius" value="0.1" />
       <param name="planning_horizon_m" value="4.0" />
       <param name="autostart" value="true" />
       <param name="verbose" value="true" />

--- a/mav_hilbert_planner/src/mav_hilbert_planner.cpp
+++ b/mav_hilbert_planner/src/mav_hilbert_planner.cpp
@@ -178,7 +178,6 @@ void MavHilbertPlanner::planningTimerCallback(const ros::TimerEvent& event) {
 
 void MavHilbertPlanner::hilbertmapTimerCallback(const ros::TimerEvent& event) {
     hilbert_mapper_.setMapCenter(odometry_.position_W);
-    std::cout << "Map refresh" << std::endl;
 }
 
 void MavHilbertPlanner::planningStep() {

--- a/mav_hilbert_planner/src/mav_hilbert_planner.cpp
+++ b/mav_hilbert_planner/src/mav_hilbert_planner.cpp
@@ -11,6 +11,7 @@ MavHilbertPlanner::MavHilbertPlanner(const ros::NodeHandle& nh,
       nh_private_(nh_private),
       command_publishing_spinner_(1, &command_publishing_queue_),
       planning_spinner_(1, &planning_queue_),
+      maprefresh_spinner_(1, &maprefresh_queue_),
       verbose_(false),
       global_frame_id_("map"),
       local_frame_id_("odom"),
@@ -18,7 +19,7 @@ MavHilbertPlanner::MavHilbertPlanner(const ros::NodeHandle& nh,
       command_publishing_dt_(1.0),
       replan_dt_(1.0),
       replan_lookahead_sec_(0.1),
-      maprefresh_dt_(10.0),
+      maprefresh_dt_(3.0),
       avoid_collisions_(true),
       autostart_(true),
       smoother_name_("loco"),
@@ -75,16 +76,16 @@ MavHilbertPlanner::MavHilbertPlanner(const ros::NodeHandle& nh,
 
   // Start the planning timer. Will no-op most cycles.
   ros::TimerOptions timer_options(
-      ros::Duration(maprefresh_dt_),
+      ros::Duration(replan_dt_),
       boost::bind(&MavHilbertPlanner::planningTimerCallback, this, _1),
       &planning_queue_);
 
   planning_timer_ = nh_.createTimer(timer_options);
 
   ros::TimerOptions map_timer_options(
-    ros::Duration(replan_dt_),
+    ros::Duration(maprefresh_dt_),
     boost::bind(&MavHilbertPlanner::hilbertmapTimerCallback, this, _1),
-    &hilbertmap_queue_);
+    &maprefresh_queue_);
 
 
   hilbertmapupdate_timer_ = nh_.createTimer(map_timer_options);
@@ -92,6 +93,7 @@ MavHilbertPlanner::MavHilbertPlanner(const ros::NodeHandle& nh,
   // Start the command publishing spinner.
   command_publishing_spinner_.start();
   planning_spinner_.start();
+  maprefresh_spinner_.start();
 
   // Set up yaw policy.
   yaw_policy_.setPhysicalConstraints(constraints_);
@@ -176,6 +178,7 @@ void MavHilbertPlanner::planningTimerCallback(const ros::TimerEvent& event) {
 
 void MavHilbertPlanner::hilbertmapTimerCallback(const ros::TimerEvent& event) {
     hilbert_mapper_.setMapCenter(odometry_.position_W);
+    std::cout << "Map refresh" << std::endl;
 }
 
 void MavHilbertPlanner::planningStep() {


### PR DESCRIPTION
This PR enables trajectory planning in hilbertmaps.

This is the first state on the hilbertmaps starting to work with the loco planner.

![screenshot from 2019-02-25 21-15-03](https://user-images.githubusercontent.com/5248102/53366019-e4289380-3942-11e9-8fbf-9e5c840b836c.png)
