### PR TITLE
Fix HilbertMap visualization

### DIFF
--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -12,7 +12,7 @@ hilbertMapper::hilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& n
 
     hilbertMap_.reset(new hilbertmap(1000));
 
-    cmdloop_timer_ = nh_.createTimer(ros::Duration(0.25), &hilbertMapper::cmdloopCallback, this); // Define timer for constant loop rate
+    cmdloop_timer_ = nh_.createTimer(ros::Duration(0.1), &hilbertMapper::cmdloopCallback, this); // Define timer for constant loop rate
     statusloop_timer_ = nh_.createTimer(ros::Duration(2), &hilbertMapper::statusloopCallback, this); // Define timer for constant loop rate
 
     mapinfoPub_ = nh_.advertise<hilbert_msgs::MapperInfo>("/hilbert_mapper/info", 1);

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -109,29 +109,20 @@ void hilbertMapper::publishMap(){
 
     sensor_msgs::PointCloud2 hilbert_map_msg;
     pcl::PointCloud<pcl::PointXYZI> pointCloud;
-    Eigen::Vector3d x_query, origin;
+    Eigen::Vector3d x_query;
 
     //Encode pointcloud data
-    int width_cells = int(width_ / resolution_);
-    origin << 0.5 * width_, 0.5 * width_, 0.5 * width_;
+    for(int i = 0; i < hilbertMap_->getNumFeatures(); i ++) {
+        pcl::PointXYZI point;
+        x_query = hilbertMap_->getFeature(i);
+        point.x = x_query(0);
+        point.y = x_query(1);
+        point.z = x_query(2);
+        point.intensity = hilbertMap_->getOccupancyProb(x_query);
 
-    for(int i = 0; i < width_cells; i ++) {
-        for (int j = 0; j < width_cells; j++) {
-            for (int k = 0; k < width_cells; k++) {
-                pcl::PointXYZI point;
-                double occ_prob;
-                x_query << i * resolution_, j * resolution_ , k * resolution_;
-                x_query = x_query - origin;
-
-                point.x = x_query(0);
-                point.y = x_query(1);
-                point.z = x_query(2);
-                point.intensity = hilbertMap_->getOccupancyProb(x_query);
-
-                pointCloud.points.push_back(point);
-            }
-        }
+        pointCloud.points.push_back(point);
     }
+
     pcl::toROSMsg(pointCloud, hilbert_map_msg);
 
     hilbert_map_msg.header.stamp = ros::Time::now();
@@ -186,7 +177,6 @@ void hilbertMapper::publishAnchorPoints() {
     Eigen::Vector3d x_feature, origin;
 
     //Encode pointcloud data
-    int width_cells = int(width_ / resolution_);
     for(int i = 0; i < hilbertMap_->getNumFeatures(); i ++) {
         pcl::PointXYZ point;
         x_feature = hilbertMap_->getFeature(i);


### PR DESCRIPTION
This PR fixes the HilbertMap visualization replaces the complex logic to a more simple way as the following
- Visualize the map only on anchorpoints
- Fix issue where anchorpoints were moving while hilbertmaps were not moving