### PR TITLE
Enable separate shape for wlh

### DIFF
--- a/hilbert_mapper/include/hilbert_mapper/hilbert_mapper.h
+++ b/hilbert_mapper/include/hilbert_mapper/hilbert_mapper.h
@@ -57,7 +57,6 @@ class HilbertMapper
     int index_pointcloud;
     string frame_id_;
     double resolution_;
-    double width_;
     float tsdf_threshold_;
     bool publish_hilbertmap_, publish_mapinfo_, publish_gridmap_, publish_anchorpoints_, 
         publish_binpoints_, publish_debuginfo_;

--- a/hilbert_mapper/include/hilbert_mapper/hilbertmap.h
+++ b/hilbert_mapper/include/hilbert_mapper/hilbertmap.h
@@ -21,6 +21,7 @@ class hilbertmap
         int max_iterations_;
         int prelearn_iterations_;
         int num_samples_;
+        int num_cells_[3]; //Anchorpoint size
         double eta_; //Learning Rate
         double width_, length_, height_;
         double resolution_;
@@ -28,6 +29,7 @@ class hilbertmap
         double time_sgd_; // Convergence time for stochastic gradient descent
         double sigma_; // Covariance for RBF Kernel
         float tsdf_threshold_;
+        double sgd_amount_;
 
         Eigen::Vector3d pointcloud;
         Eigen::Vector3d map_center_;
@@ -40,7 +42,8 @@ class hilbertmap
 
         Eigen::VectorXd getNegativeLikelyhood(std::vector<int> &index);
         void stochasticGradientDescent(Eigen::VectorXd &weights);
-        double sgd_amount_;
+        void generateGridPoints(std::vector<Eigen::Vector3d> &gridpoints, Eigen::Vector3d center, double width, double length, double height, double resolution);
+        void resizeGridPoints(std::vector<Eigen::Vector3d> &gridpoints, Eigen::Vector3d center, double width, double length, double height);
 
 public:
         hilbertmap(int num_feature);
@@ -49,8 +52,8 @@ public:
         void appendBin(pcl::PointCloud<pcl::PointXYZI> &ptcloud);
         void setMapProperties(int num_samples, double width, double length, double height, double resolution, float tsdf_threshold);
         void setMapCenter(Eigen::Vector3d map_center);
+        void setMapCenter(Eigen::Vector3d map_center, double width, double length, double height);
         void getkernelVector(const Eigen::Vector3d& x_query, Eigen::VectorXd &kernel_vector) const;
-        void generateGridPoints(std::vector<Eigen::Vector3d> &gridpoints, Eigen::Vector3d center, double width, double length, double height, double resolution);
         
         int getBinSize();
         int getNumFeatures();
@@ -60,6 +63,8 @@ public:
         bool getOccProbAndGradientAtPosition(const Eigen::Vector3d& x_query, double* occprob, Eigen::Vector3d* gradient) const;
 
         double getMapWidth();
+        double getMapLength();
+        double getMapHeight();
         double getMapResolution();
         double getSgdTime();
         double getQueryTime();

--- a/hilbert_mapper/include/hilbert_mapper/hilbertmap.h
+++ b/hilbert_mapper/include/hilbert_mapper/hilbertmap.h
@@ -22,7 +22,7 @@ class hilbertmap
         int prelearn_iterations_;
         int num_samples_;
         double eta_; //Learning Rate
-        double width_;
+        double width_, length_, height_;
         double resolution_;
         double time_query_; // Time for querying a single time
         double time_sgd_; // Convergence time for stochastic gradient descent
@@ -47,7 +47,7 @@ public:
         virtual ~hilbertmap();
         void updateWeights();
         void appendBin(pcl::PointCloud<pcl::PointXYZI> &ptcloud);
-        void setMapProperties(int num_samples, double width, double resolution, float tsdf_threshold);
+        void setMapProperties(int num_samples, double width, double length, double height, double resolution, float tsdf_threshold);
         void setMapCenter(Eigen::Vector3d map_center);
         void getkernelVector(const Eigen::Vector3d& x_query, Eigen::VectorXd &kernel_vector) const;
         void generateGridPoints(std::vector<Eigen::Vector3d> &gridpoints, Eigen::Vector3d center, double width, double length, double height, double resolution);

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -90,19 +90,21 @@ void HilbertMapper::pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr&
     pcl::PointCloud<pcl::PointXYZI>::Ptr ptcloud(new pcl::PointCloud<pcl::PointXYZI>);
     pcl::PointCloud<pcl::PointXYZI>::Ptr cropped_ptcloud(new pcl::PointCloud<pcl::PointXYZI>);
     Eigen::Vector3d map_center;
-    float map_width;
+    float map_width, map_length, map_height;
     pcl::fromROSMsg(*msg, *ptcloud); //Convert PointCloud2 to PCL vectors
 
     // Crop PointCloud around map center
     pcl::CropBox<pcl::PointXYZI> boxfilter;
     map_center = hilbertMap_->getMapCenter();
     map_width = 0.5 * float(hilbertMap_->getMapWidth());
+    map_length = 0.5 * float(hilbertMap_->getMapLength());
+    map_height = 0.5 * float(hilbertMap_->getMapHeight());
     float minX = float(map_center(0) - map_width);
-    float minY = float(map_center(1) - map_width);
-    float minZ = float(map_center(2) - map_width);
+    float minY = float(map_center(1) - map_length);
+    float minZ = float(map_center(2) - map_height);
     float maxX = float(map_center(0) + map_width);
-    float maxY = float(map_center(1) + map_width);
-    float maxZ = float(map_center(2) + map_width);
+    float maxY = float(map_center(1) + map_length);
+    float maxZ = float(map_center(2) + map_height);
     boxfilter.setMin(Eigen::Vector4f(minX, minY, minZ, 0.0));
     boxfilter.setMax(Eigen::Vector4f(maxX, maxY, maxZ, 1.0));
     boxfilter.setInputCloud(ptcloud);

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -29,11 +29,14 @@ HilbertMapper::HilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& n
     pointcloudSub_ = nh_.subscribe("/hilbert_mapper/tsdf_pointcloud", 1, &HilbertMapper::pointcloudCallback, this,ros::TransportHints().tcpNoDelay());
 
     int num_samples, num_features;
+    double width, length, height;
 
     nh_.param<int>("/hilbert_mapper/num_parsingsampels", num_samples, 100);
     nh_.param<string>("/hilbert_mapper/frame_id", frame_id_, "world");
     nh_.param<double>("/hilbert_mapper/map/resolution", resolution_, 0.5);
-    nh_.param<double>("/hilbert_mapper/map/width", width_, 5.0);
+    nh_.param<double>("/hilbert_mapper/map/width", width, 5.0);
+    nh_.param<double>("/hilbert_mapper/map/length", length, 5.0);
+    nh_.param<double>("/hilbert_mapper/map/height", height, 5.0);
     nh_.param<float>("/hilbert_mapper/map/tsdf_threshold", tsdf_threshold_, 0.5);
     nh_.param<bool>("/hilbert_mapper/publsih_hilbertmap", publish_hilbertmap_, true);
     nh_.param<bool>("/hilbert_mapper/publsih_mapinfo", publish_mapinfo_, true);
@@ -41,7 +44,7 @@ HilbertMapper::HilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& n
     nh_.param<bool>("/hilbert_mapper/publsih_gridmap", publish_gridmap_, false);
     nh_.param<bool>("/hilbert_mapper/publsih_anchorpoints", publish_anchorpoints_, true);
     nh_.param<bool>("/hilbert_mapper/publsih_binpoints", publish_binpoints_, true);
-    hilbertMap_->setMapProperties(num_samples, width_, resolution_, tsdf_threshold_);
+    hilbertMap_->setMapProperties(num_samples, width, length, height, resolution_, tsdf_threshold_);
 }
 HilbertMapper::~HilbertMapper() {
   //Destructor

--- a/hilbert_mapper/src/hilbertmap.cpp
+++ b/hilbert_mapper/src/hilbertmap.cpp
@@ -13,13 +13,15 @@ hilbertmap::hilbertmap(int num_features):
     A_(Eigen::MatrixXd::Identity(num_features, num_features)),
     eta_(0.3),
     width_(5.0),
+    length_(5.0),
+    height_(5.0),
     resolution_(0.5),
     tsdf_threshold_(0.5),
     sigma_(0.4) {
 
     map_center_ = Eigen::Vector3d::Zero();
 
-    generateGridPoints(anchorpoints_, map_center_, width_, width_, width_, resolution_);
+    generateGridPoints(anchorpoints_, map_center_, width_, length_, height_, resolution_);
 
 }
 hilbertmap::~hilbertmap() {
@@ -92,11 +94,13 @@ void hilbertmap::appendBin(pcl::PointCloud<pcl::PointXYZI> &ptcloud) {
     appendbin_timer.Stop();
 }
 
-void hilbertmap::setMapProperties(int num_samples, double width, double resolution, float tsdf_threshold){
+void hilbertmap::setMapProperties(int num_samples, double width, double length, double height, double resolution, float tsdf_threshold){
 
     num_samples_ = num_samples;
-    num_features_ = std::pow(int(width / resolution), 3);
+    num_features_ = int(width / resolution) * int(length / resolution) * int(height / resolution);
     width_ = width;
+    length_ = length;
+    height_ = height;
     resolution_ = resolution;
 
     A_ = Eigen::MatrixXd::Identity(num_features_, num_features_);


### PR DESCRIPTION
This PR enables defining a rectuangular anchorpoint pattern by defining the widht, length, height of the anchorpoint grid pattern. The resolution is all the same for all dimensions