### PR TITLE
Improve bin handling

### DIFF
--- a/hilbert_mapper/include/hilbert_mapper/hilbert_mapper.h
+++ b/hilbert_mapper/include/hilbert_mapper/hilbert_mapper.h
@@ -49,6 +49,7 @@ class hilbertMapper
     ros::Subscriber mavtransformSub_;
     ros::Subscriber poseSub_;
     ros::Subscriber pointcloudSub_;
+    ros::Time last_received_tsdfmap_;
 
     Eigen::Vector3d mavPos_;
     Eigen::Vector4d mavAtt_;

--- a/hilbert_mapper/include/hilbert_mapper/hilbertmap.h
+++ b/hilbert_mapper/include/hilbert_mapper/hilbertmap.h
@@ -36,6 +36,7 @@ class hilbertmap
         std::vector<Eigen::Vector3d> anchorpoints_;
         std::vector<Eigen::Vector3d> prelearned_anchorpoints_;
         std::vector<pcl::PointXYZI> bin_;
+        ros::Time last_received_tsdfmap_;
 
         Eigen::VectorXd getNegativeLikelyhood(std::vector<int> &index);
         void stochasticGradientDescent(Eigen::VectorXd &weights);

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -80,6 +80,10 @@ void hilbertMapper::setMapCenter(Eigen::Vector3d &position){
 
 void hilbertMapper::pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg){
 
+    ros::Time current_time = ros::Time::now();
+    if((current_time - last_received_tsdfmap_).toSec() < 0.5) return;
+
+    //Drop Messages if they are comming in too fast
     pcl::PointCloud<pcl::PointXYZI>::Ptr ptcloud(new pcl::PointCloud<pcl::PointXYZI>);
     pcl::PointCloud<pcl::PointXYZI>::Ptr cropped_ptcloud(new pcl::PointCloud<pcl::PointXYZI>);
     Eigen::Vector3d map_center;
@@ -101,6 +105,9 @@ void hilbertMapper::pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr&
     boxfilter.setInputCloud(ptcloud);
     boxfilter.filter(*cropped_ptcloud);
     hilbertMap_->appendBin(*cropped_ptcloud);
+
+    last_received_tsdfmap_ = current_time;
+
 }
 
 void hilbertMapper::publishMapInfo(){

--- a/hilbert_mapper/src/hilbertmap.cpp
+++ b/hilbert_mapper/src/hilbertmap.cpp
@@ -78,19 +78,17 @@ Eigen::VectorXd hilbertmap::getNegativeLikelyhood(std::vector<int> &index){
 
 void hilbertmap::appendBin(pcl::PointCloud<pcl::PointXYZI> &ptcloud) {
 
-    std::srand(std::time(nullptr));
-    int num_observations = ptcloud.points.size();
-
-    for(int i = 0; i < std::min(num_observations, num_samples_); i++){
-        int idx = std::rand() % num_observations;
-        //TODO: Should we handle duplicate points?
-        if(ptcloud[idx].intensity < tsdf_threshold_) bin_.emplace_back(pcl::PointXYZI(1.0f));
+    voxblox::timing::Timer appendbin_timer("hilbertmap/appendbin_time");
+    bin_.clear();
+    for(int i = 0; i < ptcloud.points.size(); i++){
+        if(ptcloud[i].intensity < tsdf_threshold_) bin_.emplace_back(pcl::PointXYZI(1.0f));
         else bin_.emplace_back(pcl::PointXYZI(-1.0f));
 
-        bin_.back().x = ptcloud[idx].x;
-        bin_.back().y = ptcloud[idx].y;
-        bin_.back().z = ptcloud[idx].z;
+        bin_.back().x = ptcloud[i].x;
+        bin_.back().y = ptcloud[i].y;
+        bin_.back().z = ptcloud[i].z;
     }
+    appendbin_timer.Stop();
 }
 
 void hilbertmap::setMapProperties(int num_samples, double width, double resolution, float tsdf_threshold){


### PR DESCRIPTION
This PR improves Bin handling by getting rid of bin sampling from TSDF maps and use a cropped TSDF map directly. 
- This gets rid of having an additional sampled intermediate representation of the world.
- This removes the complexity of managing the bin as removing once the bin points are too far away and managing the population of bin points to represent the map properly

![screenshot from 2019-03-04 16-07-06](https://user-images.githubusercontent.com/5248102/53743152-73313080-3e9a-11e9-9c65-bae7ac8da12a.png)