### PR TITLE
Refactor confusing class names

### DIFF
--- a/hilbert_mapper/include/hilbert_mapper/hilbert_mapper.h
+++ b/hilbert_mapper/include/hilbert_mapper/hilbert_mapper.h
@@ -33,7 +33,7 @@ using namespace Eigen;
 
 typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
 
-class hilbertMapper
+class HilbertMapper
 {
   private:
     ros::NodeHandle nh_;
@@ -76,8 +76,8 @@ class hilbertMapper
     void publishBinPoints();
 
 public:
-    hilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
-    virtual ~ hilbertMapper();
+    HilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+    virtual ~ HilbertMapper();
     double voxel_size(){ return 0.5 * resolution_; };
     void setMapCenter(Eigen::Vector3d &position);
     

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -5,7 +5,7 @@
 using namespace Eigen;
 using namespace std;
 //Constructor
-hilbertMapper::hilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
+HilbertMapper::HilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
   nh_(nh),
   nh_private_(nh_private),
   index_pointcloud(0),
@@ -13,9 +13,9 @@ hilbertMapper::hilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& n
 
     hilbertMap_.reset(new hilbertmap(1000));
 
-    cmdloop_timer_ = nh_.createTimer(ros::Duration(0.1), &hilbertMapper::cmdloopCallback, this); // Define timer for constant loop rate
-    statusloop_timer_ = nh_.createTimer(ros::Duration(0.5), &hilbertMapper::statusloopCallback, this); // Define timer for constant loop rate
-    faststatusloop_timer_ = nh_.createTimer(ros::Duration(0.01), &hilbertMapper::faststatusloopCallback, this); // Define timer for constant loop rate
+    cmdloop_timer_ = nh_.createTimer(ros::Duration(0.1), &HilbertMapper::cmdloopCallback, this); // Define timer for constant loop rate
+    statusloop_timer_ = nh_.createTimer(ros::Duration(0.5), &HilbertMapper::statusloopCallback, this); // Define timer for constant loop rate
+    faststatusloop_timer_ = nh_.createTimer(ros::Duration(0.01), &HilbertMapper::faststatusloopCallback, this); // Define timer for constant loop rate
 
     mapinfoPub_ = nh_.advertise<hilbert_msgs::MapperInfo>("/hilbert_mapper/info", 1);
     debuginfoPub_ = nh_.advertise<hilbert_msgs::Debug>("/hilbert_mapper/debug", 1);
@@ -26,7 +26,7 @@ hilbertMapper::hilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& n
     gridmapPub_ = nh_.advertise<nav_msgs::OccupancyGrid>("/hilbert_mapper/gridmap", 1);
 
 
-    pointcloudSub_ = nh_.subscribe("/hilbert_mapper/tsdf_pointcloud", 1, &hilbertMapper::pointcloudCallback, this,ros::TransportHints().tcpNoDelay());
+    pointcloudSub_ = nh_.subscribe("/hilbert_mapper/tsdf_pointcloud", 1, &HilbertMapper::pointcloudCallback, this,ros::TransportHints().tcpNoDelay());
 
     int num_samples, num_features;
 
@@ -43,16 +43,16 @@ hilbertMapper::hilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& n
     nh_.param<bool>("/hilbert_mapper/publsih_binpoints", publish_binpoints_, true);
     hilbertMap_->setMapProperties(num_samples, width_, resolution_, tsdf_threshold_);
 }
-hilbertMapper::~hilbertMapper() {
+HilbertMapper::~HilbertMapper() {
   //Destructor
 }
 
-void hilbertMapper::cmdloopCallback(const ros::TimerEvent& event) {
+void HilbertMapper::cmdloopCallback(const ros::TimerEvent& event) {
     //Update HilbertMap weights
     hilbertMap_->updateWeights();
 }
 
-void hilbertMapper::statusloopCallback(const ros::TimerEvent &event) {
+void HilbertMapper::statusloopCallback(const ros::TimerEvent &event) {
     //Slower loop to publish status / info related topics
 
     //Reset Map center
@@ -67,18 +67,18 @@ void hilbertMapper::statusloopCallback(const ros::TimerEvent &event) {
     }
 }
 
-void hilbertMapper::faststatusloopCallback(const ros::TimerEvent &event) {
+void HilbertMapper::faststatusloopCallback(const ros::TimerEvent &event) {
     if(publish_debuginfo_) publishDebugInfo();
 
 }
 
-void hilbertMapper::setMapCenter(Eigen::Vector3d &position){
+void HilbertMapper::setMapCenter(Eigen::Vector3d &position){
     mavPos_ = position;
     hilbertMap_->setMapCenter(mavPos_);
 
 }
 
-void hilbertMapper::pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg){
+void HilbertMapper::pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr& msg){
 
     ros::Time current_time = ros::Time::now();
     if((current_time - last_received_tsdfmap_).toSec() < 0.5) return;
@@ -110,7 +110,7 @@ void hilbertMapper::pointcloudCallback(const sensor_msgs::PointCloud2::ConstPtr&
 
 }
 
-void hilbertMapper::publishMapInfo(){
+void HilbertMapper::publishMapInfo(){
     hilbert_msgs::MapperInfo msg;
 
     msg.header.stamp = ros::Time::now();
@@ -123,7 +123,7 @@ void hilbertMapper::publishMapInfo(){
     mapinfoPub_.publish(msg);
 }
 
-void hilbertMapper::publishDebugInfo(){
+void HilbertMapper::publishDebugInfo(){
     hilbert_msgs::Debug msg;
 
     msg.header.stamp = ros::Time::now();
@@ -133,7 +133,7 @@ void hilbertMapper::publishDebugInfo(){
     debuginfoPub_.publish(msg);
 }
 
-void hilbertMapper::publishMap(){
+void HilbertMapper::publishMap(){
 
     sensor_msgs::PointCloud2 hilbert_map_msg;
     pcl::PointCloud<pcl::PointXYZI> pointCloud;
@@ -162,7 +162,7 @@ void hilbertMapper::publishMap(){
     publish_map_timer.Stop();
 }
 
-void hilbertMapper::publishgridMap(){
+void HilbertMapper::publishgridMap(){
 
     nav_msgs::OccupancyGrid grid_map;
     int num_features;
@@ -201,7 +201,7 @@ void hilbertMapper::publishgridMap(){
     gridmapPub_.publish(grid_map);
 }
 
-void hilbertMapper::publishAnchorPoints() {
+void HilbertMapper::publishAnchorPoints() {
 
     sensor_msgs::PointCloud2 anchorpoint_msg;
     pcl::PointCloud<pcl::PointXYZ> pointCloud;
@@ -225,7 +225,7 @@ void hilbertMapper::publishAnchorPoints() {
     anchorPub_.publish(anchorpoint_msg);
 }
 
-void hilbertMapper::publishBinPoints() {
+void HilbertMapper::publishBinPoints() {
 
     sensor_msgs::PointCloud2 binpoint_msg;
     pcl::PointCloud<pcl::PointXYZI> pointCloud;

--- a/hilbert_mapper/src/hilbert_mapper_node.cpp
+++ b/hilbert_mapper/src/hilbert_mapper_node.cpp
@@ -8,7 +8,7 @@ int main(int argc, char** argv) {
   ros::NodeHandle nh("");
   ros::NodeHandle nh_private("~");
 
-  hilbertMapper hilbertmapper(nh, nh_private);
+  HilbertMapper Hilbertmapper(nh, nh_private);
   ros::spin();
   return 0;
 }

--- a/hilbert_mappublisher/include/hilbert_mappublisher/hilbert_mappublisher.h
+++ b/hilbert_mappublisher/include/hilbert_mappublisher/hilbert_mappublisher.h
@@ -14,7 +14,7 @@
 #include <pcl/PCLPointCloud2.h>
 
 
-class hilbertMapPublisher
+class HilbertMapPublisher
 {
   private:
     ros::NodeHandle nh_;
@@ -34,8 +34,8 @@ class hilbertMapPublisher
     void pubPointCloud();
 
 public:
-    hilbertMapPublisher(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
-    virtual ~ hilbertMapPublisher();
+    HilbertMapPublisher(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);
+    virtual ~ HilbertMapPublisher();
 };
 
 #endif

--- a/hilbert_mappublisher/src/hilbert_mappublisher.cpp
+++ b/hilbert_mappublisher/src/hilbert_mappublisher.cpp
@@ -3,12 +3,12 @@
 #include "hilbert_mappublisher/hilbert_mappublisher.h"
 
 //Constructor
-hilbertMapPublisher::hilbertMapPublisher(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
+HilbertMapPublisher::HilbertMapPublisher(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private):
   nh_(nh),
   nh_private_(nh_private),
   mapcenter_(Eigen::Vector3d::Zero()){
 
-    cmdloop_timer_ = nh_.createTimer(ros::Duration(0.1), &hilbertMapPublisher::cmdloopCallback, this); // Define timer for constant loop rate
+    cmdloop_timer_ = nh_.createTimer(ros::Duration(0.1), &HilbertMapPublisher::cmdloopCallback, this); // Define timer for constant loop rate
 
     mapcenterPub_ = nh_.advertise<geometry_msgs::PoseStamped>("/mappublisher/pose", 1);
     pointcloudPub_ = nh_.advertise<sensor_msgs::PointCloud2>("/mappublisher/pointcloud", 2);
@@ -17,11 +17,11 @@ hilbertMapPublisher::hilbertMapPublisher(const ros::NodeHandle& nh, const ros::N
     nh_.param<double>("/hilbert_mappublisher/resolution", map_resolution_, 0.1); //[m/cells]
 }
 
-hilbertMapPublisher::~hilbertMapPublisher() {
+HilbertMapPublisher::~HilbertMapPublisher() {
   //Destructor
 }
 
-void hilbertMapPublisher::cmdloopCallback(const ros::TimerEvent& event) {
+void HilbertMapPublisher::cmdloopCallback(const ros::TimerEvent& event) {
 
     pubMapCenter();
     pubPointCloud();
@@ -29,7 +29,7 @@ void hilbertMapPublisher::cmdloopCallback(const ros::TimerEvent& event) {
     ros::spinOnce();
 }
 
-void hilbertMapPublisher::pubMapCenter() {
+void HilbertMapPublisher::pubMapCenter() {
 
     geometry_msgs::PoseStamped mapcenterpose_msg;
 
@@ -46,7 +46,7 @@ void hilbertMapPublisher::pubMapCenter() {
     mapcenterPub_.publish(mapcenterpose_msg);
 }
 
-void hilbertMapPublisher::pubPointCloud(){
+void HilbertMapPublisher::pubPointCloud(){
 
     sensor_msgs::PointCloud2 pointcloud_msg;
     pcl::PointCloud<pcl::PointXYZI> pointCloud;

--- a/hilbert_mappublisher/src/hilbert_mappublisher_node.cpp
+++ b/hilbert_mappublisher/src/hilbert_mappublisher_node.cpp
@@ -8,7 +8,7 @@ int main(int argc, char** argv) {
   ros::NodeHandle nh("");
   ros::NodeHandle nh_private("~");
 
-  hilbertMapPublisher hilbertmapper(nh, nh_private);
+  HilbertMapPublisher hilbertmapper(nh, nh_private);
   ros::spin();
   return 0;
 }

--- a/mav_hilbert_planner/include/mav_hilbert_planner/mav_hilbert_planner.h
+++ b/mav_hilbert_planner/include/mav_hilbert_planner/mav_hilbert_planner.h
@@ -172,7 +172,7 @@ class MavHilbertPlanner {
   int num_failures_;
 
   // Map!
-  hilbertMapper hilbert_mapper_;
+  HilbertMapper hilbert_mapper_;
   voxblox::TsdfServer tsdf_server_;
 
   // Planners -- yaw policy


### PR DESCRIPTION
This PR is just a simple refactor on the confusing class names

`hilbertMapper` -> `HilbertMapper`
`hilbertMap` -> `HilbertMap`