### PR TITLE
Publish surface of hilbert maps

### DIFF
--- a/hilbert_mapper/include/hilbert_mapper/hilbert_mapper.h
+++ b/hilbert_mapper/include/hilbert_mapper/hilbert_mapper.h
@@ -45,6 +45,7 @@ class HilbertMapper
     ros::Publisher gridmapPub_;
     ros::Publisher anchorPub_;
     ros::Publisher binPub_;
+    ros::Publisher collisionsurfacePub_;
     ros::Subscriber mavposeSub_;
     ros::Subscriber mavtransformSub_;
     ros::Subscriber poseSub_;
@@ -60,7 +61,7 @@ class HilbertMapper
     double width_;
     float tsdf_threshold_;
     bool publish_hilbertmap_, publish_mapinfo_, publish_gridmap_, publish_anchorpoints_, 
-        publish_binpoints_, publish_debuginfo_;
+        publish_binpoints_, publish_debuginfo_, publish_collisionsurface_;
     bool verbose_;
 
     void cmdloopCallback(const ros::TimerEvent& event);
@@ -74,6 +75,7 @@ class HilbertMapper
     void publishgridMap();
     void publishAnchorPoints();
     void publishBinPoints();
+    void publishCollisionSurface();
 
 public:
     HilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& nh_private);

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -245,7 +245,7 @@ void HilbertMapper::publishBinPoints() {
     binPub_.publish(binpoint_msg);
 }
 
-void hilbertMapper::publishCollisionSurface(){
+void HilbertMapper::publishCollisionSurface(){
 
     sensor_msgs::PointCloud2 collisionmap_surface;
     pcl::PointCloud<pcl::PointXYZI> pointCloud;

--- a/hilbert_mapper/src/hilbert_mapper.cpp
+++ b/hilbert_mapper/src/hilbert_mapper.cpp
@@ -35,13 +35,13 @@ HilbertMapper::HilbertMapper(const ros::NodeHandle& nh, const ros::NodeHandle& n
     nh_.param<double>("/hilbert_mapper/map/resolution", resolution_, 0.5);
     nh_.param<double>("/hilbert_mapper/map/width", width_, 5.0);
     nh_.param<float>("/hilbert_mapper/map/tsdf_threshold", tsdf_threshold_, 0.5);
-    nh_.param<bool>("/hilbert_mapper/publsih_hilbertmap", publish_hilbertmap_, false);
+    nh_.param<bool>("/hilbert_mapper/publsih_hilbertmap", publish_hilbertmap_, true);
     nh_.param<bool>("/hilbert_mapper/publsih_mapinfo", publish_mapinfo_, true);
     nh_.param<bool>("/hilbert_mapper/publsih_debuginfo", publish_debuginfo_, true);
     nh_.param<bool>("/hilbert_mapper/publsih_gridmap", publish_gridmap_, false);
     nh_.param<bool>("/hilbert_mapper/publsih_anchorpoints", publish_anchorpoints_, true);
     nh_.param<bool>("/hilbert_mapper/publsih_binpoints", publish_binpoints_, true);
-    nh_.param<bool>("/hilbert_mapper/publsih_collisionsurface", publish_collisionsurface_, true);
+    nh_.param<bool>("/hilbert_mapper/publsih_collisionsurface", publish_collisionsurface_, false);
     hilbertMap_->setMapProperties(num_samples, width_, resolution_, tsdf_threshold_);
 }
 HilbertMapper::~HilbertMapper() {


### PR DESCRIPTION
This PR publishes only the collision surface of the hilbertmap.

It is disabled by default.