### PR TITLE
Always abort if a path cannot be found

### DIFF
--- a/mav_hilbert_planner/src/mav_hilbert_planner.cpp
+++ b/mav_hilbert_planner/src/mav_hilbert_planner.cpp
@@ -236,20 +236,14 @@ void MavHilbertPlanner::avoidCollisionsTowardWaypoint() {
     success = loco_planner_.getTrajectoryTowardGoal(path_chunk.front(),
                                                     waypoint, &trajectory);
     if (!success) {
-      if (path_chunk_collision_free) {
-        ROS_INFO(
-            "[Mav Local Planner][Plan Step] Couldn't find a solution :( "
-            "Continuing existing solution.");
-      } else {
-        ROS_INFO(
-            "[Mav Local Planner][Plan Step] ABORTING! No local solution "
-            "found.");
-        abort();
-        num_failures_++;
-        if (num_failures_ > max_failures_) {
-          current_waypoint_ = -1;
-        }
-      }
+      ROS_INFO(
+          "[Mav Local Planner][Plan Step] ABORTING! No local solution "
+          "found.");
+      abort();
+      num_failures_++;
+      if (num_failures_ > max_failures_) {
+        current_waypoint_ = -1;
+      }      
       return;
     } else {
       ROS_INFO("[Mav Local Planner][Plan Step] Appending new path chunk.");


### PR DESCRIPTION
Previous:
- If there a new plan cannot be found and the previous path was found to be collision free, stay on the previous plan

This results in dangerous behaviors when the trajectory traverses unknown space but was discovered to be occupied.

Changed:
- always abort when a path is not found